### PR TITLE
Update instructions for new Chrome design

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This is a Chrome extension, sorry if you have Firefox or Safari or whatever.
 1. Download the ZIP by [clicking
    here](https://github.com/morgane/declutter-twitter/archive/master.zip).
 1. Unzip the ZIP.
-1. Go to your [extensions page](chrome://extensions/).
+1. Go to your extensions page at `chrome://extensions/`.
 1. Check the "Developer mode" checkbox. (image below)
-1. Click "Load unpacked extension..."
+1. Click "Load Unpacked"
 1. Select the unzipped folder (not the actual .zip file).
 1. You did it!!!
 
-![](https://user-images.githubusercontent.com/257678/33810866-7ce0afee-ddbf-11e7-940a-6461625b5c75.png)
+![](https://user-images.githubusercontent.com/257678/37552602-e26f4080-2975-11e8-9e0f-ff45302e00a8.png)


### PR DESCRIPTION
The extensions page looks totally different now.

Old image: 

![](https://user-images.githubusercontent.com/257678/33810866-7ce0afee-ddbf-11e7-940a-6461625b5c75.png)

---------------

New image:

![](https://user-images.githubusercontent.com/257678/37552602-e26f4080-2975-11e8-9e0f-ff45302e00a8.png)

